### PR TITLE
removed deprecated text.latex.unicode rcparam

### DIFF
--- a/vplot/vplot.mplstyle
+++ b/vplot/vplot.mplstyle
@@ -29,7 +29,6 @@ text.color                    : k
 
 # LATEX
 text.usetex                   : False
-text.latex.unicode            : False
 text.latex.preamble           :
 text.hinting                  : auto
 text.hinting_factor           : 8


### PR DESCRIPTION
This PR removes a matplotlib rcparam that will deprecated in matplotlib 3.1.

Below is the matplotlib warning when setting text.latex.unicode:

/Users/dflemin3/anaconda3/lib/python3.6/site-packages/matplotlib/__init__.py:846: MatplotlibDeprecationWarning: 
The text.latex.unicode rcparam was deprecated in Matplotlib 2.2 and will be removed in 3.1.
  "2.2", name=key, obj_type="rcparam", addendum=addendum)